### PR TITLE
Add target files as other files to QT project

### DIFF
--- a/GenerateQTProject/src/Generator.cs
+++ b/GenerateQTProject/src/Generator.cs
@@ -116,6 +116,18 @@ namespace GenerateQTProject
                 qtProFile = qtProFile + "\n\n" +
                 "DISTFILES += \\\n\t" +
                 "../../Source/" + projectName + "/" + projectName + ".Build.cs";
+
+                // Add targets as additional files
+                string[] files = Directory.GetFiles(projectDir + "\\Source\\");
+                foreach (string file in files)
+                {
+                    if (file.EndsWith(".Target.cs"))
+                    {
+                        qtProFile = qtProFile + "\n\n" +
+                        "DISTFILES += \\\n\t" +
+                        "../../Source/" + Path.GetFileName(file);
+                    }
+                }
             }
 
             try


### PR DESCRIPTION
Recently noticed that *.Target.cs files are not included in project so i made little change to add them to other files during project generation ;)
